### PR TITLE
Fix poetry version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,15 +2,18 @@
 
 [[package]]
 name = "asgiref"
-version = "3.7.0"
+version = "3.7.1"
 description = "ASGI specs, helper code, and adapters"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "asgiref-3.7.0-py3-none-any.whl", hash = "sha256:14087924af5be5d8103d6f2edffe45a0bf7ab1b2a771b6f00a6db8c302f21f34"},
-    {file = "asgiref-3.7.0.tar.gz", hash = "sha256:5d6c4a8a1c99f58eaa3bc392ee04e3587b693f09e3af1f3f16a09094f334eb52"},
+    {file = "asgiref-3.7.1-py3-none-any.whl", hash = "sha256:33958cb2e4b3cd8b1b06ef295bd8605cde65b11df51d3beab39e2e149a610ab3"},
+    {file = "asgiref-3.7.1.tar.gz", hash = "sha256:8de379fcc383bcfe4507e229fc31209ea23d4831c850f74063b2c11639474dd2"},
 ]
+
+[package.dependencies]
+typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
 
 [package.extras]
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
@@ -47,6 +50,21 @@ tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 [package.extras]
 argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.1.1"
+description = "Backport of PEP 654 (exception groups)"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
+    {file = "exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "iniconfig"
@@ -102,9 +120,11 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
@@ -127,6 +147,30 @@ doc = ["sphinx"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.6.2"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "typing_extensions-4.6.2-py3-none-any.whl", hash = "sha256:3a8b36f13dd5fdc5d1b16fe317f5668545de77fa0b8e02006381fd49d731ab98"},
+    {file = "typing_extensions-4.6.2.tar.gz", hash = "sha256:06006244c70ac8ee83fa8282cb188f697b8db25bc8b4df07be1873c43897060c"},
+]
+
+[[package]]
 name = "tzdata"
 version = "2023.3"
 description = "Provider of IANA time zone data"
@@ -140,5 +184,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.11"
-content-hash = "f8daf94b2888258df72012e816315b0643182ead2078c573c6cd63b84ba8fe2c"
+python-versions = "^3.10"
+content-hash = "358ddcad3828727dced08d4c2aa9052ad78a97de8eeda573dffd4f43f09df8b3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,9 @@ authors = ["Paul Tiplady <paultiplady@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.11"
-Django = "^4.2.1"
+python = "^3.10"
+django = "^4.2.1"
+
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"

--- a/shell.nix
+++ b/shell.nix
@@ -2,8 +2,11 @@
 let
   myAppEnv = pkgs.poetry2nix.mkPoetryEnv {
     projectDir = ./.;
-    python = pkgs.python311;
+#    python = pkgs.python310;
   };
 in myAppEnv.env.overrideAttrs (oldAttrs: {
-  buildInputs = [ pkgs.postgresql ];
+#  buildInputs = [ pkgs.postgresql ];
 })
+#pkgs.mkShell {
+#  buildInputs = [ pkgs.python310 pkgs.poetry ];
+#}


### PR DESCRIPTION
Now we're getting this error:

```
direnv: loading ~/git/newpy/.envrc
direnv: ([/nix/store/f98d4y1ysqn12qycfajlpi2klg3ql5kw-direnv-2.32.1/bin/direnv export zsh]) is taking a while to execute. Use CTRL-C to give up.
error: builder for '/nix/store/9zjc05p9dhbi3412rfrdh8q1fzvqn4px-python3.10-sqlparse-0.4.4.drv' failed with exit code 2;
       last 10 log lines:
       >   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
       >   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
       >   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
       > ModuleNotFoundError: No module named 'flit_core'
       >
       >
       For full logs, run 'nix log /nix/store/9zjc05p9dhbi3412rfrdh8q1fzvqn4px-python3.10-sqlparse-0.4.4.drv'.
error: 1 dependencies of derivation '/nix/store/b6hq5frlj2jfrgylyiz25w49d7b70vsy-python3-3.10.11-env.drv' failed to build
error: 1 dependencies of derivation '/nix/store/bqkngdqrlkawzsmypy0bb7iwgl7axfdm-interactive-python3-3.10.11-environment-env.drv' failed to build
direnv: nix-direnv: renewed cache
direnv: export +XDG_DATA_DIRS

```